### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.x7YSjh1UBD
+ trap 'rm -rf /tmp/tmp.x7YSjh1UBD' EXIT
+ python -m venv /tmp/tmp.x7YSjh1UBD
+ python setup.py sdist -d /tmp/tmp.x7YSjh1UBD
running sdist
running egg_info
writing pyini.egg-info/PKG-INFO
writing dependency_links to pyini.egg-info/dependency_links.txt
writing top-level names to pyini.egg-info/top_level.txt
reading manifest file 'pyini.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pyini.egg-info/SOURCES.txt'
running check
creating pyini-0.1.1
creating pyini-0.1.1/pyini
creating pyini-0.1.1/pyini.egg-info
copying files to pyini-0.1.1...
copying MANIFEST.in -> pyini-0.1.1
copying README.md -> pyini-0.1.1
copying requirements.txt -> pyini-0.1.1
copying setup.py -> pyini-0.1.1
copying pyini/__init__.py -> pyini-0.1.1/pyini
copying pyini/configparser.py -> pyini-0.1.1/pyini
copying pyini.egg-info/PKG-INFO -> pyini-0.1.1/pyini.egg-info
copying pyini.egg-info/SOURCES.txt -> pyini-0.1.1/pyini.egg-info
copying pyini.egg-info/dependency_links.txt -> pyini-0.1.1/pyini.egg-info
copying pyini.egg-info/top_level.txt -> pyini-0.1.1/pyini.egg-info
Writing pyini-0.1.1/setup.cfg
Creating tar archive
removing 'pyini-0.1.1' (and everything under it)
+ cd /
+ /tmp/tmp.x7YSjh1UBD/bin/pip install /tmp/tmp.x7YSjh1UBD/pyini-0.1.1.tar.gz
Processing /tmp/tmp.x7YSjh1UBD/pyini-0.1.1.tar.gz
Installing collected packages: pyini
  Running setup.py install for pyini: started
    Running setup.py install for pyini: finished with status 'done'
Successfully installed pyini-0.1.1
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.x7YSjh1UBD
```
